### PR TITLE
Improve lanelet finding API

### DIFF
--- a/ads_scenario_transformer/tools/vector_map_parser.py
+++ b/ads_scenario_transformer/tools/vector_map_parser.py
@@ -3,6 +3,7 @@ import lanelet2
 from lanelet2.core import Lanelet, LaneletMap, TrafficLight
 from lanelet2.projection import MGRSProjector
 from lanelet2.io import Origin
+from lanelet2.traffic_rules import Locations, Participants
 
 T = TypeVar('T')
 
@@ -15,6 +16,16 @@ class VectorMapParser:
         origin = Origin(0.0, 0.0, 0.0)
         self.projector = MGRSProjector(origin)
         self.lanelet_map = lanelet2.io.load(vector_map_path, self.projector)
+
+        self.vehicle_traffic_rules = lanelet2.traffic_rules.create(
+            Locations.Germany, Participants.Vehicle)
+        self.pedestrian_traffic_rules = lanelet2.traffic_rules.create(
+            Locations.Germany, Participants.Pedestrian)
+
+        self.vehicle_routing_graph = lanelet2.routing.RoutingGraph(
+            self.lanelet_map, self.vehicle_traffic_rules)
+        self.pedestrian_routing_graph = lanelet2.routing.RoutingGraph(
+            self.lanelet_map, self.pedestrian_traffic_rules)
 
     def get_attributes(self, key: str,
                        attribute_type: Type[T]) -> Dict[int, T]:

--- a/ads_scenario_transformer/transformer/lane_waypoint_transformer.py
+++ b/ads_scenario_transformer/transformer/lane_waypoint_transformer.py
@@ -1,23 +1,21 @@
-from typing import Dict, Tuple, Optional, Set
+from typing import Tuple, Optional
 import math
 from dataclasses import dataclass
-from lanelet2.core import LaneletMap
-from lanelet2.projection import MGRSProjector
 from modules.common.proto.geometry_pb2 import PointENU
 from modules.routing.proto.routing_pb2 import LaneWaypoint
 from openscenario_msgs import Waypoint, RouteStrategy, ScenarioObject
 from ads_scenario_transformer.transformer import Transformer
-from ads_scenario_transformer.transformer.pointenu_transformer import PointENUTransformer, PointENUTransformerConfiguration
+from ads_scenario_transformer.transformer.pointenu_transformer import PointENUTransformer, PointENUTransformerConfiguration, PointENUTransformerInput
 from ads_scenario_transformer.tools.apollo_map_parser import ApolloMapParser
+from ads_scenario_transformer.tools.vector_map_parser import VectorMapParser
 
 
 @dataclass
 class LaneWaypointTransformerConfiguration:
-    lanelet_map: LaneletMap
-    projector: MGRSProjector
-    lanelet_subtypes: Set[str]
+    vector_map_parser: VectorMapParser
     scenario_object: ScenarioObject
-    apollo_map_parser: Optional[ApolloMapParser] = None
+    apollo_map_parser: ApolloMapParser
+    reference_points: Optional[Tuple[PointENU, PointENU]]
 
 
 class LaneWaypointTransformer(Transformer):
@@ -40,20 +38,20 @@ class LaneWaypointTransformer(Transformer):
         pointenu_transformer = PointENUTransformer(
             configuration=PointENUTransformerConfiguration(
                 supported_position=PointENUTransformer.SupportedPosition.Lane,
-                lanelet_map=self.configuration.lanelet_map,
-                projector=self.configuration.projector,
-                lanelet_subtypes=self.configuration.lanelet_subtypes,
-                scenario_object=self.configuration.scenario_object))
-        position = pointenu_transformer.transform((pose, heading))
+                vector_map_parser=self.configuration.vector_map_parser,
+                scenario_object=self.configuration.scenario_object,
+                reference_points=self.configuration.reference_points))
+        position = pointenu_transformer.transform(
+            PointENUTransformerInput(point=pose, heading=heading))
 
         return Waypoint(routeStrategy=RouteStrategy.ROUTESTRATEGY_SHORTEST,
                         position=position)
 
     def get_pose_from_apollo_waypoint(
-            self, source: Source) -> Tuple[PointENU, float]:
+            self, lane_waypoint: LaneWaypoint) -> Tuple[PointENU, float]:
         assert self.configuration.apollo_map_parser is not None
 
         (point, heading
          ) = self.configuration.apollo_map_parser.get_coordinate_and_heading(
-             lane_id=source.id, s=source.s)
+             lane_id=lane_waypoint.id, s=lane_waypoint.s)
         return (PointENU(x=point.x, y=point.y, z=0), heading)

--- a/ads_scenario_transformer/transformer/pointenu_transformer.py
+++ b/ads_scenario_transformer/transformer/pointenu_transformer.py
@@ -1,21 +1,26 @@
-from typing import Tuple, Optional, Set
+from typing import Tuple, Optional
 from enum import Enum
 from dataclasses import dataclass
-from lanelet2.core import LaneletMap
-from lanelet2.projection import MGRSProjector
 from modules.common.proto.geometry_pb2 import PointENU
 from openscenario_msgs import Position, LanePosition, WorldPosition, ScenarioObject, BoundingBox, Vehicle
 from ads_scenario_transformer.transformer import Transformer
 from ads_scenario_transformer.tools.geometry import Geometry
+from ads_scenario_transformer.tools.vector_map_parser import VectorMapParser
+from ads_scenario_transformer.builder.entities_builder import ASTEntityType
 
 
 @dataclass
 class PointENUTransformerConfiguration:
     supported_position: 'PointENUTransformer.SupportedPosition'
-    lanelet_map: LaneletMap
-    projector: MGRSProjector
-    lanelet_subtypes: Set[str]
-    scenario_object: Optional[ScenarioObject]
+    vector_map_parser: VectorMapParser
+    scenario_object: ScenarioObject
+    reference_points: Optional[Tuple[PointENU, PointENU]]
+
+
+@dataclass
+class PointENUTransformerInput:
+    point: PointENU
+    heading: float
 
 
 class PointENUTransformer(Transformer):
@@ -29,7 +34,7 @@ class PointENUTransformer(Transformer):
         Lane = 1
         World = 2
 
-    Source = Tuple[PointENU, float]
+    Source = PointENUTransformerInput
     Target = Optional[Position]
 
     def __init__(self, configuration: PointENUTransformerConfiguration):
@@ -44,23 +49,51 @@ class PointENUTransformer(Transformer):
 
     def transformToLanePosition(self,
                                 source: Source) -> Optional[LanePosition]:
-        lanelet_map = self.configuration.lanelet_map
-        projector = self.configuration.projector
-        lanelet_subtypes = self.configuration.lanelet_subtypes
+        vector_map_parser = self.configuration.vector_map_parser
+        lanelet_map = vector_map_parser.lanelet_map
+        projector = vector_map_parser.projector
+        entity_type = ASTEntityType.entity_type(
+            self.configuration.scenario_object)
 
         projected_point = Geometry.project_UTM_point_on_lanelet(
-            projector=projector, point=source[0])
-        lanelet = Geometry.find_lanelet(map=lanelet_map,
-                                        basic_point=projected_point,
-                                        subtypes=lanelet_subtypes)
+            projector=projector, point=source.point)
 
-        if lanelet:
+        lanelets = Geometry.find_close_lanelets(map=lanelet_map,
+                                                basic_point=projected_point,
+                                                entity_type=entity_type)
+
+        target_lanelet = None
+        if self.configuration.reference_points:
+            start_point = Geometry.project_UTM_point_on_lanelet(
+                projector=projector,
+                point=self.configuration.reference_points[0])
+            end_point = Geometry.project_UTM_point_on_lanelet(
+                projector=projector,
+                point=self.configuration.reference_points[-1])
+
+            lanes_in_route = Geometry.find_available_lanes(
+                vector_map_parser=vector_map_parser,
+                start_point=start_point,
+                end_point=end_point,
+                entity_type=entity_type)
+
+            avaiable_lane_id = [lanelet.id for lanelet in lanes_in_route]
+
+            for lanelet in lanelets:
+                if lanelet.id in avaiable_lane_id:
+                    target_lanelet = lanelet
+                    break
+
+        if not target_lanelet and len(lanelets) > 0:
+            target_lanelet = lanelets[0]
+
+        if target_lanelet:
             bounding_box = self.object_bouding_box(
                 self.configuration.scenario_object)
             # Discard heading value
             lane_position = Geometry.nearest_lane_position(
                 map=lanelet_map,
-                lanelet=lanelet,
+                lanelet=target_lanelet,
                 basic_point=projected_point,
                 entity_bounding_box=bounding_box,
                 heading=0.0)
@@ -69,7 +102,8 @@ class PointENUTransformer(Transformer):
 
     def transformToWorldPosition(self, source: Source) -> WorldPosition:
         projected_point = Geometry.project_UTM_point_on_lanelet(
-            projector=self.configuration.projector, point=source[0])
+            projector=self.configuration.vector_map_parser.projector,
+            point=source.point)
         # Discard heading value
         return WorldPosition(x=projected_point.x,
                              y=projected_point.y,

--- a/ads_scenario_transformer/transformer/routing_request_transformer.py
+++ b/ads_scenario_transformer/transformer/routing_request_transformer.py
@@ -1,22 +1,21 @@
-from typing import Optional
+from typing import Optional, Tuple
 from dataclasses import dataclass
-from lanelet2.core import LaneletMap
-from lanelet2.projection import MGRSProjector
+from modules.common.proto.geometry_pb2 import PointENU
 from modules.routing.proto.routing_pb2 import RoutingRequest
 from openscenario_msgs import Private, ScenarioObject
 from ads_scenario_transformer.transformer import Transformer
 from ads_scenario_transformer.transformer.lane_waypoint_transformer import LaneWaypointTransformer, LaneWaypointTransformerConfiguration
-from ads_scenario_transformer.builder.entities_builder import ASTEntityType
 from ads_scenario_transformer.builder.private_builder import PrivateBuilder
 from ads_scenario_transformer.tools.apollo_map_parser import ApolloMapParser
+from ads_scenario_transformer.tools.vector_map_parser import VectorMapParser
 
 
 @dataclass
 class RoutingRequestTransformerConfiguration:
-    lanelet_map: LaneletMap
-    projector: MGRSProjector
+    vector_map_parser: VectorMapParser
+    apollo_map_parser: ApolloMapParser
     ego_scenario_object: ScenarioObject
-    apollo_map_parser: Optional[ApolloMapParser] = None
+    reference_points: Optional[Tuple[PointENU, PointENU]]
 
 
 class RoutingRequestTransformer(Transformer):
@@ -33,11 +32,10 @@ class RoutingRequestTransformer(Transformer):
 
         transformer = LaneWaypointTransformer(
             configuration=LaneWaypointTransformerConfiguration(
-                lanelet_map=self.configuration.lanelet_map,
-                projector=self.configuration.projector,
+                vector_map_parser=self.configuration.vector_map_parser,
                 apollo_map_parser=self.configuration.apollo_map_parser,
-                lanelet_subtypes=ASTEntityType.EGO.available_lanelet_subtype(),
-                scenario_object=self.configuration.ego_scenario_object))
+                scenario_object=self.configuration.ego_scenario_object,
+                reference_points=self.configuration.reference_points))
 
         openscenario_waypoints = map(
             lambda lane_waypoint:

--- a/scripts/sampling.py
+++ b/scripts/sampling.py
@@ -1,0 +1,69 @@
+import os
+import random
+import argparse
+import shutil
+
+
+def find_files(directory, extension):
+    """Recursively find all files in the given directory with a specific extension."""
+    for root, dirs, files in os.walk(directory):
+        for file in files:
+            if file.endswith(extension):
+                yield os.path.join(root, file)
+
+
+def randomly_select_files(directory, num_files=1, extension=".00000"):
+    """Randomly select a specified number of files with a specific extension from a directory, including its subdirectories."""
+    all_files = list(find_files(directory, extension))
+    if len(all_files) == 0:
+        return []
+    selected_files = random.sample(all_files, min(len(all_files), num_files))
+    return selected_files
+
+
+def copy_files(files, target_directory):
+    """Copy selected files to the target directory."""
+    if not os.path.exists(target_directory):
+        os.makedirs(target_directory)
+    for file in files:
+        shutil.copy(file, target_directory)
+        print(f"Copied {file} to {target_directory}")
+
+
+def parse_args():
+    """Parse command-line arguments."""
+    parser = argparse.ArgumentParser(
+        description=
+        'Randomly select and copy files with a specific extension from a specified directory.'
+    )
+    parser.add_argument('directory',
+                        type=str,
+                        help='The directory to search for files.')
+    parser.add_argument('num_files',
+                        type=int,
+                        help='The number of files to randomly select.')
+    parser.add_argument('target_directory',
+                        type=str,
+                        help='The directory to copy the selected files to.')
+    parser.add_argument('-e',
+                        '--extension',
+                        type=str,
+                        default=".00000",
+                        help='File extension to filter by (default is .00000)')
+    return parser.parse_args()
+
+
+if __name__ == "__main__":
+    args = parse_args()
+    if args.num_files < 1:
+        print("Please specify at least one file.")
+    else:
+        selected_files = randomly_select_files(args.directory, args.num_files,
+                                               args.extension)
+        if not selected_files:
+            print("No files found with the specified extension.")
+        else:
+            print("Randomly selected files:")
+            for file in selected_files:
+                print(file)
+            copy_files(selected_files, args.target_directory)

--- a/scripts/scenario_player/experiment_runner.py
+++ b/scripts/scenario_player/experiment_runner.py
@@ -268,4 +268,4 @@ if __name__ == '__main__':
                                               docker_image_id=DOCKER_IMAGE_ID,
                                               container_timeout_sec=120))
 
-    runner.run_experiment(output_summary=True, enable_recording=True)
+    runner.run_experiment(output_summary=True, enable_recording=False)

--- a/scripts/setup_env.sh
+++ b/scripts/setup_env.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+if [ -d ".venv" ]; then
+    echo "Activating virtual environment..."
+    source .venv/bin/activate
+else
+    python3 -m venv .venv
+    source .venv/bin/activate
+    pip install poetry
+    poetry install    
+fi
+
+export PYTHONPATH=/home/sora/Desktop/changnam/ADS-scenario-transfer/.venv/lib/python3.10/dist-packages
+

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,6 +10,8 @@ from ads_scenario_transformer.builder.parameter_declarations_builder import Para
 from ads_scenario_transformer.builder.entities_builder import ASTEntityType, EntitiesBuilder, ASTEntity
 from ads_scenario_transformer.openscenario.openscenario_coder import OpenScenarioDecoder
 from ads_scenario_transformer.builder.scenario_builder import ScenarioBuilder, ScenarioConfiguration
+from modules.localization.proto.localization_pb2 import LocalizationEstimate
+from ads_scenario_transformer.tools.cyber_record_reader import CyberRecordReader, CyberRecordChannel
 
 import lanelet2
 from lanelet2.projection import MGRSProjector
@@ -42,8 +44,14 @@ def borregas_doppel_scenario160_path() -> str:
 
 
 @pytest.fixture
+def borregas_doppel_scenario48_path() -> str:
+    return SAMPLE_ROOT + "/apollo_borregas/DoppelTest/00000048.00000"
+
+
+@pytest.fixture
 def borregas_doppel_scenario9_path() -> str:
     return SAMPLE_ROOT + "/apollo_borregas/DoppelTest/00000009.00000"
+
 
 @pytest.fixture
 def sf_doppel_scenario_path() -> str:
@@ -76,19 +84,27 @@ def vector_map_parser(borregas_vector_map_path) -> ApolloMapParser:
 
 
 @pytest.fixture
+def localization_poses(
+        borregas_doppel_scenario48_path) -> List[LocalizationEstimate]:
+    return CyberRecordReader.read_channel(
+        source_path=borregas_doppel_scenario48_path,
+        channel=CyberRecordChannel.LOCALIZATION_POSE)
+
+
+@pytest.fixture
 def scenario(storyboard) -> Scenario:
-    ast_entities=[
+    ast_entities = [
         ASTEntity(entity_type=ASTEntityType.EGO,
-                   use_default_scenario_object=True),
+                  use_default_scenario_object=True),
         ASTEntity(entity_type=ASTEntityType.CAR,
-                   use_default_scenario_object=True),
+                  use_default_scenario_object=True),
         ASTEntity(entity_type=ASTEntityType.CAR,
-                   use_default_scenario_object=True)
+                  use_default_scenario_object=True)
     ]
     entities_builder = EntitiesBuilder()
     for ast_entity in ast_entities:
-        builder.add_entity(ast_entity)
-        
+        entities_builder.add_entity(ast_entity)
+
     entities = entities_builder.get_result()
 
     scenario_config = ScenarioConfiguration(
@@ -104,18 +120,18 @@ def scenario(storyboard) -> Scenario:
 def ast_entities() -> List[ASTEntity]:
     return [
         ASTEntity(entity_type=ASTEntityType.CAR,
-                   use_default_scenario_object=True),
+                  use_default_scenario_object=True),
         ASTEntity(embedding_id=100,
-                   entity_type=ASTEntityType.CAR,
-                   use_default_scenario_object=True),
+                  entity_type=ASTEntityType.CAR,
+                  use_default_scenario_object=True),
         ASTEntity(entity_type=ASTEntityType.EGO,
-                   use_default_scenario_object=True),
+                  use_default_scenario_object=True),
         ASTEntity(embedding_id=200,
-                   entity_type=ASTEntityType.PEDESTRIAN,
-                   use_default_scenario_object=True),
+                  entity_type=ASTEntityType.PEDESTRIAN,
+                  use_default_scenario_object=True),
         ASTEntity(embedding_id=300,
-                   entity_type=ASTEntityType.CAR,
-                   use_default_scenario_object=True)
+                  entity_type=ASTEntityType.CAR,
+                  use_default_scenario_object=True)
     ]
 
 

--- a/tests/test_lane_waypoint_transformer.py
+++ b/tests/test_lane_waypoint_transformer.py
@@ -2,49 +2,31 @@ from modules.common.proto.geometry_pb2 import PointENU
 from modules.routing.proto.routing_pb2 import LaneWaypoint
 from ads_scenario_transformer.transformer import LaneWaypointTransformer
 from ads_scenario_transformer.transformer.lane_waypoint_transformer import LaneWaypointTransformerConfiguration
-from ads_scenario_transformer.builder.entities_builder import ASTEntityType
 
 
-def test_utm_type_lane_waypoint_transformer(lanelet_map, mgrs_projector,
-                                            entities):
-    point = PointENU(x=587079.3045861976, y=4141574.299574421, z=0)
+def test_utm_type_lane_waypoint_transformer(vector_map_parser,
+                                            apollo_map_parser, entities,
+                                            localization_poses):
 
-    lane_waypoint = LaneWaypoint(pose=point)
-
-    transformer = LaneWaypointTransformer(
-        configuration=LaneWaypointTransformerConfiguration(
-            lanelet_map=lanelet_map,
-            projector=mgrs_projector,
-            lanelet_subtypes=ASTEntityType.EGO.available_lanelet_subtype(),
-            scenario_object=entities.scenarioObjects[0]))
-
-    openscenario_waypoint = transformer.transform(source=lane_waypoint)
-
-    lane_position = openscenario_waypoint.position.lanePosition
-
-    assert lane_position.laneId == "22"
-    assert lane_position.offset == 0.2289137647592503
-    assert lane_position.s == 35.812947374714085
-    assert lane_position.orientation.h == 0
-
-
-def test_laneId_type_lane_waypoint_transformer(lanelet_map, mgrs_projector,
-                                               apollo_map_parser, entities):
-    lane_waypoint = LaneWaypoint(id="lane_26", s=26.2)
+    point = localization_poses[56].pose.position
+    pose = PointENU(x=point.x, y=point.y, z=point.z)
+    lane_waypoint = LaneWaypoint(pose=pose)
 
     transformer = LaneWaypointTransformer(
         configuration=LaneWaypointTransformerConfiguration(
-            lanelet_map=lanelet_map,
-            projector=mgrs_projector,
+            vector_map_parser=vector_map_parser,
+            scenario_object=entities.scenarioObjects[0],
             apollo_map_parser=apollo_map_parser,
-            lanelet_subtypes=ASTEntityType.EGO.available_lanelet_subtype(),
-            scenario_object=entities.scenarioObjects[0]))
+            reference_points=[
+                localization_poses[0].pose.position,
+                localization_poses[-1].pose.position
+            ]))
 
     openscenario_waypoint = transformer.transform(source=lane_waypoint)
 
     lane_position = openscenario_waypoint.position.lanePosition
 
-    assert lane_position.laneId == "149"
-    assert lane_position.offset == 0.9375
-    assert lane_position.s == 26.739416492972932
-    assert lane_position.orientation.h == 0.0
+    assert lane_position.laneId == "15"
+    assert lane_position.offset == -0.21234711002946863
+    assert lane_position.s == 44.94214913248086
+    assert lane_position.orientation.h == 0

--- a/tests/test_obstacles_transformer.py
+++ b/tests/test_obstacles_transformer.py
@@ -20,8 +20,7 @@ def test_obstacle_transformer(perception_obstacles, vector_map_parser):
     obstacles_transformer = ObstaclesTransformer(
         configuration=ObstaclesTransformerConfiguration(
             sceanrio_start_timestamp=sceanrio_start_timestamp,
-            lanelet_map=vector_map_parser.lanelet_map,
-            projector=vector_map_parser.projector,
+            vector_map_parser=vector_map_parser,
             waypoint_frequency_in_sec=1,
             direction_change_detection_threshold=60))
 

--- a/tests/test_pointenu_transformer.py
+++ b/tests/test_pointenu_transformer.py
@@ -1,20 +1,21 @@
 from modules.common.proto.geometry_pb2 import PointENU
 from ads_scenario_transformer.transformer import PointENUTransformer
-from ads_scenario_transformer.transformer.pointenu_transformer import PointENUTransformerConfiguration
+from ads_scenario_transformer.transformer.pointenu_transformer import PointENUTransformerConfiguration, PointENUTransformerInput
 
 
-def test_transform_world_position(lanelet_map, mgrs_projector, entities):
+def test_transform_world_position(localization_poses, vector_map_parser,
+                                  entities):
     point = PointENU(x=587079.3045861976, y=4141574.299574421, z=0)
     worldType = PointENUTransformer.SupportedPosition.World
 
     transformer = PointENUTransformer(
         configuration=PointENUTransformerConfiguration(
             supported_position=worldType,
-            lanelet_map=lanelet_map,
-            projector=mgrs_projector,
-            lanelet_subtypes=set(),
-            scenario_object=entities.scenarioObjects[0]))
-    position = transformer.transform(source=(point, 0.0))
+            vector_map_parser=vector_map_parser,
+            scenario_object=entities.scenarioObjects[0],
+            reference_points=None))
+    position = transformer.transform(
+        source=PointENUTransformerInput(point, 0.0))
 
     assert position.worldPosition is not None, "The gpspoint should not be None."
     assert position.worldPosition.x == 87079.30458619667
@@ -22,19 +23,20 @@ def test_transform_world_position(lanelet_map, mgrs_projector, entities):
     assert position.worldPosition.z == 0.0
 
 
-def test_transform_lane_position(lanelet_map, mgrs_projector, entities):
+def test_transform_lane_position(localization_poses, vector_map_parser,
+                                 entities):
 
     point = PointENU(x=587079.3045861976, y=4141574.299574421, z=0)
     laneType = PointENUTransformer.SupportedPosition.Lane
     transformer = PointENUTransformer(
         configuration=PointENUTransformerConfiguration(
             supported_position=laneType,
-            lanelet_map=lanelet_map,
-            projector=mgrs_projector,
-            lanelet_subtypes=set(),
-            scenario_object=entities.scenarioObjects[0]))
+            vector_map_parser=vector_map_parser,
+            scenario_object=entities.scenarioObjects[0],
+            reference_points=None))
 
-    position = transformer.transform(source=(point, 0.0))
+    position = transformer.transform(
+        source=PointENUTransformerInput(point, 0.0))
 
     assert position.lanePosition is not None, "The lane_position should not be None."
     assert position.lanePosition.laneId == "22"

--- a/tests/test_routing_request_transformer.py
+++ b/tests/test_routing_request_transformer.py
@@ -17,15 +17,15 @@ def assert_proto_type_equal(reflection_type, pb2_type):
     assert str(reflection_type.__class__) == str(pb2_type)
 
 
-def test_routing_request(lanelet_map, mgrs_projector, ego_scenario_object,
+def test_routing_request(vector_map_parser, ego_scenario_object,
                          apollo_map_parser, borregas_doppel_scenario9_path):
 
     routing_request_transformer = RoutingRequestTransformer(
         configuration=RoutingRequestTransformerConfiguration(
-            lanelet_map=lanelet_map,
-            projector=mgrs_projector,
+            vector_map_parser=vector_map_parser,
             apollo_map_parser=apollo_map_parser,
-            ego_scenario_object=ego_scenario_object))
+            ego_scenario_object=ego_scenario_object,
+            reference_points=None))
 
     routing_requests = CyberRecordReader.read_channel(
         source_path=borregas_doppel_scenario9_path,
@@ -61,15 +61,15 @@ def test_routing_request(lanelet_map, mgrs_projector, ego_scenario_object,
     assert end_lane_position.orientation.h == 0.0
 
 
-def test_routing_request_from_response(lanelet_map, mgrs_projector,
+def test_routing_request_from_response(vector_map_parser,
                                        borregas_doppel_scenario9_path,
                                        ego_scenario_object, apollo_map_parser):
     routing_request_transformer = RoutingRequestTransformer(
         configuration=RoutingRequestTransformerConfiguration(
-            lanelet_map=lanelet_map,
-            projector=mgrs_projector,
+            vector_map_parser=vector_map_parser,
             apollo_map_parser=apollo_map_parser,
-            ego_scenario_object=ego_scenario_object))
+            ego_scenario_object=ego_scenario_object,
+            reference_points=None))
     routing_responses = CyberRecordReader.read_channel(
         source_path=borregas_doppel_scenario9_path,
         channel=CyberRecordChannel.ROUTING_RESPONSE)

--- a/tests/test_scenario_transformer.py
+++ b/tests/test_scenario_transformer.py
@@ -60,12 +60,12 @@ def test_scenario_transformer(borregas_doppel_scenario9_path,
 def test_gen_all_samples(borregas_vector_map_path, borregas_apollo_map_path,
                          borregas_scenorita_scenario9_path,
                          borregas_scenorita_scenario75_path,
-                         borregas_doppel_scenario9_path):
+                         borregas_doppel_scenario9_path,
+                         borregas_doppel_scenario48_path):
 
     scenario_paths = [
-        borregas_scenorita_scenario9_path,
-        borregas_scenorita_scenario75_path,
-        borregas_doppel_scenario9_path,
+        borregas_scenorita_scenario9_path, borregas_scenorita_scenario75_path,
+        borregas_doppel_scenario9_path, borregas_doppel_scenario48_path
     ]
 
     for scenario_path in scenario_paths:
@@ -82,10 +82,10 @@ def test_gen_all_samples(borregas_vector_map_path, borregas_apollo_map_path,
         scenario_yaml = OpenScenarioEncoder.encode_proto_pyobject_to_yaml(
             proto_pyobject=scenario, wrap_result_with_typename=False)
 
-        # filename = Path(scenario_path).parent.stem + "-" + Path(
-        #     scenario_path).stem
+    #     filename = Path(scenario_path).parent.stem + "-" + Path(
+    #         scenario_path).stem
 
-        # with open(f"{filename}.yaml", 'w') as file:
-        #     file.write(scenario_yaml)
+    #     with open(f"{filename}.yaml", 'w') as file:
+    #         file.write(scenario_yaml)
 
     # assert True == False


### PR DESCRIPTION
If multiple lanelets are overlapped and they are all same type, we cannot decide which lanelet includes provided point.  This PR allows adding reference points to the Geometry API to find lanelets. These reference points are the start/end points that make up the routing trajectory and are used to help determine which lanelet that point belongs to.